### PR TITLE
Update API Gateway domain

### DIFF
--- a/salling_group_holidays/api.py
+++ b/salling_group_holidays/api.py
@@ -9,7 +9,7 @@ class SallingGroupHolidaysException(BaseException):
 class v1:
     def __init__(self, api_key):
         self._api_key = api_key
-        self._url = 'https://api.dansksupermarked.dk/v1/holidays'
+        self._url = 'https://api.sallinggroup.com/v1/holidays'
 
     def _make_request(self, params, path='/'):
         headers = {'Authorization': 'Bearer {}'.format(self._api_key)}


### PR DESCRIPTION
Hi, Kasper

Dansk Supermarked changed its name to Salling Group some years ago and
as a consequence they've changed most public-facing domains. This
includes the API Gateway's domain, which has changed from

```
api.dansksupermarked.dk
```

to

```
api.sallinggroup.com
```

The old domain still works, but it will eventually cease to receive TLS
certificate updates and later be decommissioned entirely.

This pull request simply updates the domain so the library will remain
functional when the old domain stops working.